### PR TITLE
Add warning that docs are outdated

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,6 +7,11 @@
 Welcome to the OpenShift SDN Developer Docs
 ============================================
 
+Note: This is now outdated. Please see OpenShift SDN/OpenShift OVN Kubernetes READMEs and OpenShift Cluster Network Operator (CNO) README/wiki pages at their respective OpenShift GitHub repositories for the latest information:
+OpenShift SDN: https://github.com/openshift/sdn/tree/master/docs
+OpenShift OVN Kubernetes: https://github.com/openshift/ovn-kubernetes/tree/master/docs
+OpenShift Cluster Network Operator (CNO): https://github.com/openshift/cluster-network-operator/tree/master/docs, https://github.com/openshift/cluster-network-operator/wiki
+
 Contents:
 
 .. toctree::


### PR DESCRIPTION
Following migration of these docs to their
repos respective READMEs/wikis, I am adding
a notice to warn consumers that these docs
are now outdated.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>